### PR TITLE
Add support for hostPath volumes

### DIFF
--- a/charts/code-server/templates/deployment.yaml
+++ b/charts/code-server/templates/deployment.yaml
@@ -74,11 +74,7 @@ spec:
         {{- end }}
           volumeMounts:
           - name: data
-            mountPath: /home/coder/project
-            subPath: project
-          - name: data
-            mountPath: /home/coder/.local/share/code-server
-            subPath: code-server
+            mountPath: /home/coder
           {{- range .Values.extraConfigmapMounts }}
           - name: {{ .name }}
             mountPath: {{ .mountPath }}

--- a/charts/code-server/templates/deployment.yaml
+++ b/charts/code-server/templates/deployment.yaml
@@ -126,19 +126,31 @@ spec:
       volumes:
       - name: data
       {{- if .Values.persistence.enabled }}
+        {{- if not .Values.persistence.hostPath }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "code-server.fullname" .) }}
+        {{- else }}
+        hostPath:
+          path: {{ .Values.persistence.hostPath }}
+          type: Directory
+        {{- end -}}
       {{- else }}
         emptyDir: {}
       {{- end -}}
       {{- range .Values.extraSecretMounts }}
-        - name: {{ .name }}
-          secret:
-            secretName: {{ .secretName }}
-            defaultMode: {{ .defaultMode }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .secretName }}
+          defaultMode: {{ .defaultMode }}
       {{- end }}
       {{- range .Values.extraVolumeMounts }}
-        - name: {{ .name }}
-          persistentVolumeClaim:
-            claimName: {{ .existingClaim }}
+      - name: {{ .name }}
+        {{- if .existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .existingClaim }}
+        {{- else }}
+        hostPath:
+          path: {{ .hostPath }}
+          type: Directory
+        {{- end }}
       {{- end }}

--- a/charts/code-server/templates/pvc.yaml
+++ b/charts/code-server/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and (and .Values.persistence.enabled (not .Values.persistence.existingClaim)) (not .Values.persistence.hostPath) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/code-server/values.yaml
+++ b/charts/code-server/values.yaml
@@ -115,6 +115,7 @@ persistence:
   size: 1Gi
   annotations: {}
   # existingClaim: ""
+  # hostPath: /data
 
 serviceAccount:
   create: true
@@ -152,6 +153,7 @@ extraVolumeMounts: []
   #   mountPath: /mnt/volume
   #   readOnly: true
   #   existingClaim: volume-claim
+  #   hostPath: ""
 
 extraConfigmapMounts: []
   # - name: certs-configmap


### PR DESCRIPTION
This adds support for `hostPath` volumes to the persistence volume as well as extra mounts. This helps in scenarios where someone wants to install the helm chart on a development machine with an existing directory containing the project. Using `hostPath` he/she can continue working with a native VS code and switch back and forth to/from the web-based code-server.